### PR TITLE
Fixed click on drag and zoom issues

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -21,7 +21,10 @@
   var mouseProto = $.ui.mouse.prototype,
       _mouseInit = mouseProto._mouseInit,
       _mouseDestroy = mouseProto._mouseDestroy,
-      touchHandled;
+      touchHandled, touchTimer,
+      dragIgnoreTime = 150, // When dragging less than 150ms we see it as a tap
+      dragIgnoreDistance = 5, // When dragging less than 10px we see it as a tap unless longer than dragIgnoreTime
+      longTapTime = 750; // LongTap tie in ms
 
   /**
    * Simulate a mouse event based on a corresponding touch event
@@ -41,22 +44,23 @@
         simulatedEvent = document.createEvent('MouseEvents');
     
     // Initialize the simulated mouse event using the touch event's coordinates
+    // Make sure that the container of droppables has position: relative to make dragging work when zoomed in
     simulatedEvent.initMouseEvent(
       simulatedType,    // type
-      true,             // bubbles                    
-      true,             // cancelable                 
-      window,           // view                       
-      1,                // detail                     
-      touch.screenX,    // screenX                    
-      touch.screenY,    // screenY                    
-      touch.clientX,    // clientX                    
-      touch.clientY,    // clientY                    
-      false,            // ctrlKey                    
-      false,            // altKey                     
-      false,            // shiftKey                   
-      false,            // metaKey                    
-      0,                // button                     
-      null              // relatedTarget              
+      true,             // bubbles
+      true,             // cancelable
+      window,           // view
+      1,                // detail
+      touch.screenX,    // screenX
+      touch.screenY,    // screenY
+      touch.clientX + $(window).scrollLeft(),    // clientX + scrollLeft - fix for zoomed devices while dragging
+      touch.clientY + $(window).scrollTop(),    // clientY + scrollTop - fix for zoomed devices while dragging
+      false,            // ctrlKey
+      false,            // altKey
+      false,            // shiftKey
+      false,            // metaKey
+      0,                // button
+      null              // relatedTarget
     );
 
     // Dispatch the simulated event to the target element
@@ -69,18 +73,22 @@
    */
   mouseProto._touchStart = function (event) {
 
-    var self = this;
+    var self = this,
+      touch = event.originalEvent.changedTouches[0];
+
+    // Track movement to determine if interaction was a click
+    self._touchMoved = false;
+    self._touchStartTime = new Date().getTime();
+    self._touchStartX = touch.clientX;
+    self._touchStartY = touch.clientY;
 
     // Ignore the event if another widget is already being handled
-    if (touchHandled || !self._mouseCapture(event.originalEvent.changedTouches[0])) {
+    if (touchHandled || !self._mouseCapture(touch)) {
       return;
     }
 
     // Set the flag to prevent other widgets from inheriting the touch event
     touchHandled = true;
-
-    // Track movement to determine if interaction was a click
-    self._touchMoved = false;
 
     // Simulate the mouseover event
     simulateMouseEvent(event, 'mouseover');
@@ -90,6 +98,14 @@
 
     // Simulate the mousedown event
     simulateMouseEvent(event, 'mousedown');
+
+    // Start longTap timer
+    touchTimer = setTimeout(function () {
+      if (!self._touchMoved) {
+        event.longTap = true;
+        self._touchEnd(event);
+      }
+    }, longTapTime);
   };
 
   /**
@@ -97,14 +113,19 @@
    * @param {Object} event The document's touchmove event
    */
   mouseProto._touchMove = function (event) {
-
     // Ignore event if not handled
     if (!touchHandled) {
       return;
     }
 
-    // Interaction was not a click
-    this._touchMoved = true;
+    // Check if interaction was a click or a drag
+    var touch = event.originalEvent.changedTouches[0];
+    var holdingDownTime = new Date().getTime() - this._touchStartTime,
+      movedX = Math.abs(touch.clientX - this._touchStartX),
+      movedY = Math.abs(touch.clientY - this._touchStartY);
+    if (holdingDownTime > dragIgnoreTime || movedX > dragIgnoreDistance || movedY > dragIgnoreDistance) {
+      this._touchMoved = true;
+    }
 
     // Simulate the mousemove event
     simulateMouseEvent(event, 'mousemove');
@@ -115,7 +136,6 @@
    * @param {Object} event The document's touchend event
    */
   mouseProto._touchEnd = function (event) {
-
     // Ignore event if not handled
     if (!touchHandled) {
       return;
@@ -130,11 +150,19 @@
     // If the touch interaction did not move, it should trigger a click
     if (!this._touchMoved) {
 
-      // Simulate the click event
-      simulateMouseEvent(event, 'click');
+      // Check if it was a long tap or regular tap
+      if (event.longTap) {
+        // Simulate the right-click event
+        simulateMouseEvent(event, 'contextmenu');
+
+      } else {
+        // Simulate the click event
+        simulateMouseEvent(event, 'click');
+      }
     }
 
     // Unset the flag to allow other widgets to inherit the touch event
+    clearTimeout(touchTimer);
     touchHandled = false;
   };
 
@@ -145,7 +173,7 @@
    * original mouse event handling methods.
    */
   mouseProto._mouseInit = function () {
-    
+
     var self = this;
 
     // Delegate the touch handlers to the widget's element
@@ -163,7 +191,7 @@
    * Remove the touch event handlers
    */
   mouseProto._mouseDestroy = function () {
-    
+
     var self = this;
 
     // Delegate the touch handlers to the widget's element


### PR DESCRIPTION
1. Resolved and issue where a drag event would result in a click event after dropping.
    Decision based on the the length of the tap/drag event and the distance moved.
2. Dragging while zoomed in caused issues where the draggable showed at an incorrect position on the screen making it unusable.
   I applied the fix from Kocik's fork. Note that this only works if the container in which the draggable resides has a position: relative.   Here is the fork: https://github.com/Kocik/jquery-ui-touch-punch-zoom-fork, thanks Kocik!